### PR TITLE
Caricamento finchè la pagina non è pronta

### DIFF
--- a/web/Login.jsp
+++ b/web/Login.jsp
@@ -143,6 +143,13 @@
         </style>
     </head>
     <body id="body_id">
+        <div id="preloader-spinner" horizontal layout center style="height: 100%;">
+            <div vertical layout center style="margin: 0 auto">
+                <h1>Solo un secondo...</h1>
+                <paper-spinner active></paper-spinner>
+            </div>
+        </div>
+        <div id="after-loading" style="height: 100%; margin: 0; display: none">
         <div id="header">
             <img src="img/android.png"></img>
             <h1 id="appName">MyUnimol</h1>
@@ -185,6 +192,7 @@
                    params = '{"username":"", "password":""}'
                    handleAs='json'
                    contentId="content"></myunimol-ajax>
+        </div>
     <script>
         function sendData() {
             //prendo il core-ajax
@@ -214,6 +222,8 @@
         }
 
         document.addEventListener("polymer-ready", function() {
+            document.getElementById("preloader-spinner").style.display = "none";
+            document.getElementById("after-loading").style.display = "block";
             document.getElementById("username_input_field").focus();
 
             var appName = document.getElementById("appName");


### PR DESCRIPTION
Ho aggiunto un div di "caricamento" che resterà visibile finchè l'intero
contenuto non è stato caricato.
Tutto il contenuto è racchiuso in un div nascosto.
Quando si verifica l'evento "polymer-ready", il div di caricamento viene
nascosto ed il contenuto della pagina viene reso visibile.
Così facendo la pagina viene mostrata solamente quando è completamente
generata.

Potrebbe essere una soluzione a [questa issue](https://github.com/giograno/myUnimol_webApp/issues/12)
